### PR TITLE
syntax error in fr.php

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,9 @@ When prompted, enter a root password for MySQL.
     git clone -b gccollab https://github.com/tbs-sct/gccollab.git
 
 #### Create data directory
+
+This directory can be anywhere.  Its abosule path will be specified during installation of Ellg.
+
     mkdir gccollab_data
 
 #### Set permissions
@@ -42,6 +45,8 @@ Add the following inside the ```<VirtualHost *:80></VirtualHost>``` tag
   allow from all
 </Directory>
 ```
+
+If you copied from another vhost apache configuration file, make sure the path after the Directory instructions matches where the gccollab symlink is.
 
 Save and close (Ctrl-o then Ctrl-x if you are using nano)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ When prompted, enter a root password for MySQL.
 
 #### Create data directory
 
-This directory can be anywhere.  Its abosute path will be specified during installation of Ellg.
+This directory can be anywhere.  Its absolute path will be specified during installation of Ellg.
 
     mkdir gccollab_data
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ When prompted, enter a root password for MySQL.
 
 #### Create data directory
 
-This directory can be anywhere.  Its abosule path will be specified during installation of Ellg.
+This directory can be anywhere.  Its abosute path will be specified during installation of Ellg.
 
     mkdir gccollab_data
 

--- a/mod/cp_notifications/languages/fr.php
+++ b/mod/cp_notifications/languages/fr.php
@@ -473,7 +473,7 @@ $french = array(
 	"cp_notify:sidebar:subs_title" => "Abonnement personnel",
 	'cp_notify:pickColleagues' => 'Abonnez-vous à vos collègues', // new
 	'cp_notify:contactHelpDesk'=>'Si vous avez des questions, veuillez soumettre votre demande via le <a href="'.elgg_get_site_url().'mod/contactform/">formulaire Contactez-nous</a>.',
-    'cp_notify:visitTutorials'=>"Pour de plus amples renseignements sur GCconnex et ses fonctionnalités, consultez l'<a href='http://www.gcpedia.gc.ca/wiki/Aide_%C3%A0_l%27utilisateur/Voir_Tout'>aide à l'utilisateur de GCconnex</a>.<br/>
+    'cp_notify:visitTutorials'=>"Pour de plus amples renseignements sur GCconnex et ses fonctionnalités, consultez l'<a href='http://www.gcpedia.gc.ca/wiki/Aide_%C3%A0_l%27utilisateur/Voir_Tout'>aide à l'utilisateur de GCconnex</a>.<br/>",
 
 
 	'cp_notify:visitTutorials'=>"Pour de plus amples renseignements sur GCconnex et ses fonctionnalités, consultez l'<a href='http://www.gcpedia.gc.ca/wiki/GCconnex_-_Aide_%C3%A0_l%27utilisateur/Modifier_mes_param%C3%A8tres_de_compte/Comment_puis-je_modifier_mes_param%C3%A8tres_de_notification%3F'>aide à l'utilisateur de GCconnex</a>.<br/>

--- a/mod/custom_error_page/start.php
+++ b/mod/custom_error_page/start.php
@@ -1,4 +1,3 @@
-
 <?php
 
 elgg_register_event_handler('init', 'system', 'custom_error_page_init');


### PR DESCRIPTION
This syntax error was causing a blank page after activating the initial gccollab plugin.